### PR TITLE
Fix issue #44 : The code is changed the way that it works on the othe…

### DIFF
--- a/app/src/main/java/continuous/integration/util.java
+++ b/app/src/main/java/continuous/integration/util.java
@@ -121,7 +121,7 @@ public class util {
         		pb = new ProcessBuilder(
         				"/bin/bash",
             			"-c",
-            	        "gradlew",
+            	        "gradle",
             	        "test"
         				);
         	}
@@ -171,7 +171,7 @@ public class util {
         		pb = new ProcessBuilder(
         				"/bin/bash",
             			"-c",
-            	        "gradlew",
+            	        "gradle",
             	        "build",
             	        "-x",
             	        "test"


### PR DESCRIPTION
…r operating systems.

Code is changed the way that it works on the other operating systems. "gradlew" was not working for Mac.(Probably since it is created in Windows) So "gradle" is called instead of "gradlew" in other operating systems.